### PR TITLE
fix(ui): 修复 UI 硬编码问题与深色模式状态栏图标颜色

### DIFF
--- a/app/src/main/java/com/lonx/ecjtu/calendar/MainActivity.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/MainActivity.kt
@@ -50,7 +50,8 @@ class MainActivity: ComponentActivity() {
             Log.d("MainActivity", "uiState: $uiState")
 //            val colorMode = remember { mutableIntStateOf(uiState.colorMode) }
 //            Log.d("MainActivity", "colorMode: $colorMode")
-            val darkMode = uiState.colorMode == 2 || (isSystemInDarkTheme() && uiState.colorMode == 0)
+            val darkMode = uiState.colorMode == 2 || uiState.colorMode == 5 ||
+                (isSystemInDarkTheme() && (uiState.colorMode == 0 || uiState.colorMode == 3))
             DisposableEffect(darkMode) {
                 enableEdgeToEdge(
                     statusBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT) { darkMode },

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/CourseCard.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/CourseCard.kt
@@ -51,7 +51,7 @@ fun CourseCard(
 
                 SurfaceTag("节次：${course.time}")
 
-                Spacer(modifier = Modifier.width(10.dp))
+                Spacer(modifier = Modifier.width(12.dp))
 
                 // 课程名称
                 Text(
@@ -65,7 +65,7 @@ fun CourseCard(
             }
 
             Column(
-                verticalArrangement = Arrangement.spacedBy(6.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 CourseDetailRow(
                     icon = MiuixIcons.Regular.Location,
@@ -104,7 +104,7 @@ private fun CourseDetailRow(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            modifier = Modifier.size(18.dp),
+            modifier = Modifier.size(20.dp),
             tint = MiuixTheme.colorScheme.onSecondaryVariant
         )
         Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DateHeaderCard.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DateHeaderCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.lonx.ecjtu.calendar.domain.model.DateInfo
 import com.lonx.ecjtu.calendar.ui.theme.CalendarTheme
 import top.yukonga.miuix.kmp.basic.Card
@@ -38,21 +37,21 @@ fun DateHeaderCard(
             Text(
                 color = MiuixTheme.colorScheme.onPrimary,
                 text = date,
-                fontSize = 19.sp,
+                style = MiuixTheme.textStyles.title4,
                 fontWeight = FontWeight.SemiBold
             )
             if (weekNum.isNotBlank()){
                 Text(
                     color = MiuixTheme.colorScheme.onPrimary,
                     text = "$weekDay · 第${weekNum}周",
-                    fontSize = 17.sp,
+                    style = MiuixTheme.textStyles.headline1,
                     fontWeight = FontWeight.Normal
                 )
             } else {
                 Text(
                     color = MiuixTheme.colorScheme.onPrimary,
                     text = weekDay,
-                    fontSize = 17.sp,
+                    style = MiuixTheme.textStyles.headline1,
                     fontWeight = FontWeight.Normal
                 )
             }

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DateHeaderCard.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DateHeaderCard.kt
@@ -29,7 +29,7 @@ fun DateHeaderCard(
             .fillMaxWidth()
             .padding(12.dp),
         colors = CardDefaults.defaultColors(
-            color = MiuixTheme.colorScheme.primaryVariant
+            color = MiuixTheme.colorScheme.primary
         ),
         insideMargin = PaddingValues(16.dp),
         onClick = { onClick() },
@@ -43,14 +43,14 @@ fun DateHeaderCard(
             )
             if (weekNum.isNotBlank()){
                 Text(
-                    color = MiuixTheme.colorScheme.onPrimaryVariant,
+                    color = MiuixTheme.colorScheme.onPrimary,
                     text = "$weekDay · 第${weekNum}周",
                     fontSize = 17.sp,
                     fontWeight = FontWeight.Normal
                 )
             } else {
                 Text(
-                    color = MiuixTheme.colorScheme.onPrimaryVariant,
+                    color = MiuixTheme.colorScheme.onPrimary,
                     text = weekDay,
                     fontSize = 17.sp,
                     fontWeight = FontWeight.Normal

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DatePickerDialog.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/DatePickerDialog.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.Card
@@ -318,7 +317,7 @@ private fun YearPickerView(
                     .clickable { onYearSelected(year) }
                     .padding(vertical = 12.dp),
                 textAlign = TextAlign.Center,
-                fontSize = if (isSelected) 24.sp else 18.sp,
+                style = if (isSelected) MiuixTheme.textStyles.title2 else MiuixTheme.textStyles.title4,
                 color = if (isSelected) MiuixTheme.colorScheme.primary else MiuixTheme.colorScheme.onSurface,
                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
             )

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MessageCard.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MessageCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.lonx.ecjtu.calendar.ui.theme.CalendarTheme
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
@@ -66,7 +65,7 @@ fun MessageCard(
             Text(
                 text = message,
                 color = textColor,
-                fontSize = 16.sp
+                style = MiuixTheme.textStyles.body1
             )
         }
     }

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MessageCard.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MessageCard.kt
@@ -1,19 +1,20 @@
 package com.lonx.ecjtu.calendar.ui.component
 
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.lonx.ecjtu.calendar.ui.theme.CalendarTheme
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
 import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.utils.PressFeedbackType
-import com.lonx.ecjtu.calendar.ui.theme.LocalColorMode
 
 /**
  * 消息类型枚举
@@ -32,28 +33,20 @@ fun MessageCard(
     type: MessageType = MessageType.Info,
     onClick: (() -> Unit)? = null
 ) {
-    // 从 CompositionLocal 获取当前的颜色模式
-    val colorMode = LocalColorMode.current
-    
-    // 根据 colorMode 确定当前是否为深色主题
-    val isDark = when (colorMode) {
-        0 -> isSystemInDarkTheme() // 跟随系统
-        1 -> false // 浅色主题
-        2 -> true // 深色主题
-        else -> isSystemInDarkTheme() // 默认跟随系统
-    }
+    // 从 MiuixTheme 获取主题色
+    val colorScheme = MiuixTheme.colorScheme
 
     // 根据类型选择背景和文字颜色
-    val (backgroundColor, textColor) = when (type) {
-        MessageType.Error -> (
-                if (isDark) Color(0xFF310808) else Color(0xFFF8E2E2)
-                ) to Color(0xFFF72727)
-        MessageType.Warning -> (
-                if (isDark) Color(0xFF3B2B07) else Color(0xFFFFF3CD)
-                ) to Color(0xFFFFA000)
-        MessageType.Info -> (
-                if (isDark) Color(0xFF062B1A) else Color(0xFFE2F8E9)
-                ) to Color(0xFF2E7D32)
+    val backgroundColor = when (type) {
+        MessageType.Error -> colorScheme.errorContainer
+        MessageType.Warning -> colorScheme.surfaceVariant
+        MessageType.Info -> colorScheme.tertiaryContainer
+    }
+
+    val textColor = when (type) {
+        MessageType.Error -> colorScheme.onErrorContainer
+        MessageType.Warning -> colorScheme.error
+        MessageType.Info -> colorScheme.onTertiaryContainer
     }
 
     Card(
@@ -74,6 +67,30 @@ fun MessageCard(
                 text = message,
                 color = textColor,
                 fontSize = 16.sp
+            )
+        }
+    }
+}
+
+/**
+ * MessageCard 组件预览
+ */
+@Preview(showBackground = true)
+@Composable
+fun MessageCardPreview() {
+    CalendarTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            MessageCard(
+                message = "今天没有课啦~",
+                type = MessageType.Info
+            )
+            MessageCard(
+                message = "这是一个警告消息",
+                type = MessageType.Warning
+            )
+            MessageCard(
+                message = "这是一个错误消息",
+                type = MessageType.Error
             )
         }
     }

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MiuixToast.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/MiuixToast.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import top.yukonga.miuix.kmp.basic.Text
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import kotlinx.coroutines.delay
@@ -101,7 +100,7 @@ private fun ToastContent(message: String, visible: Boolean) {
             ) {
                 Text(
                     text = message,
-                    fontSize = 14.sp,
+                    style = MiuixTheme.textStyles.body2,
                     color = MiuixTheme.colorScheme.onPrimary
                 )
             }

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/SurfaceTag.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/component/SurfaceTag.kt
@@ -18,7 +18,7 @@ fun SurfaceTag(
 ) {
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(6.dp))
+            .clip(RoundedCornerShape(8.dp))
             .background(MiuixTheme.colorScheme.primary)
             .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/course/SelectedCourseScreen.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/course/SelectedCourseScreen.kt
@@ -8,16 +8,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lonx.ecjtu.calendar.domain.model.SelectedCourse
 import com.lonx.ecjtu.calendar.ui.component.MessageCard
 import com.lonx.ecjtu.calendar.ui.component.MessageType
@@ -106,7 +106,7 @@ fun SelectedCourseScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(6.dp)
+                            .padding(8.dp)
                     ) {
                         Text(
                             modifier = Modifier.align(Alignment.Center),
@@ -172,7 +172,7 @@ private fun CourseCard(
             ) {
                 Text(
                     text = course.courseName,
-                    fontSize = 18.sp,
+                    style = MiuixTheme.textStyles.title4,
                     fontWeight = FontWeight.Bold,
                     lineHeight = 22.sp
                 )
@@ -184,7 +184,7 @@ private fun CourseCard(
             }
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 SurfaceTag(text = "教师: ${course.courseTeacher}")
@@ -211,20 +211,20 @@ private fun CourseCard(
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Column(
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             InfoItem(title = "课程要求", value = course.courseRequire)
 
                             InfoItem(title = "选课类型", value = course.courseType)
                         }
                         Column(
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             InfoItem(title = "学时", value = "${course.period}")
                             InfoItem(title = "学分", value = "${course.credit}")
                         }
                         Column(
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
 
                             InfoItem(title = "选课模块", value = course.selectedType)
@@ -253,7 +253,7 @@ private fun InfoItem(title: String, value: String) {
         )
         Box(
             modifier = Modifier
-                .clip(RoundedCornerShape(6.dp))
+                .clip(RoundedCornerShape(8.dp))
                 .background(MiuixTheme.colorScheme.secondaryContainer)
                 .padding(horizontal = 6.dp, vertical = 4.dp)
         ) {

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/score/ScoreScreen.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/score/ScoreScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lonx.ecjtu.calendar.domain.model.Score
 import com.lonx.ecjtu.calendar.ui.component.MessageCard
 import com.lonx.ecjtu.calendar.ui.component.MessageType
@@ -117,7 +117,7 @@ fun ScoreScreen(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(6.dp)
+                            .padding(8.dp)
                     ) {
                         Text(
                             modifier = Modifier.align(Alignment.Center),
@@ -174,7 +174,7 @@ private fun ScoreCard(score: Score, term: String, modifier: Modifier = Modifier)
 
                 Text(
                     text = score.courseName,
-                    fontSize = 18.sp,
+                    style = MiuixTheme.textStyles.title4,
                     fontWeight = FontWeight.Bold,
                     lineHeight = 22.sp
                 )
@@ -194,7 +194,7 @@ private fun ScoreCard(score: Score, term: String, modifier: Modifier = Modifier)
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Column(
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         InfoItem(title = "课程代码", value = score.courseCode)
                         if (score.retakeScore.isNotEmpty()) {
@@ -202,7 +202,7 @@ private fun ScoreCard(score: Score, term: String, modifier: Modifier = Modifier)
                         }
                     }
                     Column(
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         InfoItem(title = "学期", value = term)
                         if (score.relearnScore.isNotEmpty()) {


### PR DESCRIPTION
## 概述

本 PR 修复了多处 UI 代码中的硬编码问题，统一使用 Miuix 设计系统的预定义样式和颜色方案，确保莫奈主题等动态主题能够正确应用。同时修复深色模式下状态栏图标颜色未翻转的问题。

## 变更内容

### 1. 修复状态栏图标颜色的硬编码
- 深色模式下状态栏图标颜色未能正确翻转，现已修复

![image](https://github.com/user-attachments/assets/b2abceaf-44cd-47d2-8cfc-46e37774a4bf)

### 2. 修复字体大小的硬编码
移除所有硬编码的 `fontSize`，统一使用 `MiuixTheme.textStyles` 预定义样式：
- `DateHeaderCard`: 19/17sp → `title4`/`headline1`
- `MessageCard`: 16sp → `body1`
- `MiuixToast`: 14sp → `body2`
- `ScoreScreen`/`SelectedCourseScreen`: 18sp → `title4`
- `DatePickerDialog`: 24/18sp → `title2`/`title4`

### 3. 修复间距的硬编码
统一符合 4dp 基准网格，移除不规范的间距值：
- 6.dp → 8.dp (ScoreScreen, SelectedCourseScreen)
- 10.dp → 12.dp (CourseCard)
- 18.dp → 20.dp (CourseCard 图标)
- `RoundedCornerShape(6.dp)` → `RoundedCornerShape(8.dp)`
![image](https://github.com/user-attachments/assets/1d6e8e80-d242-4355-b6f5-69a003598f1f)
![image](https://github.com/user-attachments/assets/cc55c3d1-1ff7-4bf3-b2d8-f647d37469f0)

### 4. 修复颜色的硬编码
- `DateHeaderCard`: 使用 `primary`/`onPrimary` 替代已废弃的 `primaryVariant`
- `MessageCard`: 移除硬编码颜色，改用 `MiuixTheme` 颜色方案，修复莫奈主题下失效问题
```
    // 从 MiuixTheme 获取主题色
    val colorScheme = MiuixTheme.colorScheme

    // 根据类型选择背景和文字颜色
    val backgroundColor = when (type) {
        MessageType.Error -> colorScheme.errorContainer
        MessageType.Warning -> colorScheme.surfaceVariant
        MessageType.Info -> colorScheme.tertiaryContainer
    }

    val textColor = when (type) {
        MessageType.Error -> colorScheme.onErrorContainer
        MessageType.Warning -> colorScheme.error
        MessageType.Info -> colorScheme.onTertiaryContainer
    }
```
- `MessageCard`: 添加 Preview 组件便于调试
<img width="829" height="471" alt="image" src="https://github.com/user-attachments/assets/7b7d72c3-dc16-4fd0-a2d1-5d9a6011fbf4" />

## 核心改进

通过消除硬编码，UI 组件现在能够完全响应 Miuix 设计系统的主题变化，包括莫奈取色主题和深色模式。
