### PR TITLE
feat(ui): 学期切换时显示课程数量 Toast

### DIFF
--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/viewmodel/ScoreViewModel.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/viewmodel/ScoreViewModel.kt
@@ -67,7 +67,7 @@ class ScoreViewModel(
     }
 
 
-    fun loadScores(term: String? = null, refresh: Boolean = false) {
+    fun loadScores(term: String? = null, refresh: Boolean = false, showToast: Boolean = false) {
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
@@ -87,7 +87,7 @@ class ScoreViewModel(
                         scores = scorePage.scores,
                         availableTerms = scorePage.availableTerms,
                         currentTerm = scorePage.currentTerm,
-                        toastMessage = if (refresh) "找到了 ${scorePage.scores.size} 门成绩" else null
+                        toastMessage = if (refresh || showToast) "找到了 ${scorePage.scores.size} 门成绩" else null
                     )
                 }
                 // timestamp updates are handled by observeTermRefresh()
@@ -103,7 +103,7 @@ class ScoreViewModel(
     }
 
     fun onTermSelected(newTerm: String) {
-        loadScores(term = newTerm)
+        loadScores(term = newTerm, showToast = true)
     }
 
     fun onToastShown() {

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/viewmodel/SelectedCourseViewModel.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/viewmodel/SelectedCourseViewModel.kt
@@ -64,7 +64,7 @@ class SelectedCourseViewModel(
         }
     }
 
-    fun loadCourses(term: String? = null, refresh: Boolean = false) {
+    fun loadCourses(term: String? = null, refresh: Boolean = false, showToast: Boolean = false) {
 
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
@@ -82,7 +82,7 @@ class SelectedCourseViewModel(
                         courses = coursePage.courses,
                         availableTerms = coursePage.availableTerms,
                         currentTerm = coursePage.currentTerm,
-                        toastMessage = if (refresh) "找到了 ${coursePage.courses.size} 门课程" else null
+                        toastMessage = if (refresh || showToast) "找到了 ${coursePage.courses.size} 门课程" else null
                     )
                 }
             }.onFailure { exception ->
@@ -97,7 +97,7 @@ class SelectedCourseViewModel(
     }
 
     fun onTermSelected(newTerm: String) {
-        loadCourses(term = newTerm)
+        loadCourses(term = newTerm, showToast = true)
     }
 
     fun onToastShown() {


### PR DESCRIPTION
# 功能概述

在用户切换学期时，弹出 Toast 提示显示当前学期的课程/成绩数量，提升用户交互体验。

![image](https://github.com/user-attachments/assets/3b089029-e23a-4c3e-a0ce-718991e5de03)

## 变更内容

### 修改文件
- `ScoreViewModel.kt`
- `SelectedCourseViewModel.kt`

### 具体改动
1. 为 `loadScores()` 和 `loadCourses()` 方法新增 `showToast` 参数
2. 在 `onTermSelected()` 中调用加载方法时传入 `showToast = true`
3. Toast 触发条件从仅手动刷新扩展到：手动刷新 **或** 学期切换

## 变更对比

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 下拉刷新 | 显示 Toast | 显示 Toast（保持不变） |
| 学期切换 | 无提示 | 显示 Toast（新增） |

## 关键代码

```kotlin
// ScoreViewModel.kt
fun loadScores(term: String? = null, refresh: Boolean = false, showToast: Boolean = false)

fun onTermSelected(newTerm: String) {
    loadScores(term = newTerm, showToast = true)
}

// SelectedCourseViewModel.kt
fun loadCourses(term: String? = null, refresh: Boolean = false, showToast: Boolean = false)

fun onTermSelected(newTerm: String) {
    loadCourses(term = newTerm, showToast = true)
}
```