### PR TITLE
perf: 优化多学期数据获取与列表渲染性能

### DIFF
--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/calendar/CalendarScreen.kt
@@ -90,9 +90,15 @@ fun CalendarScreen(
             overscrollEffect = null
         ) {
             if (uiState.courses.isNotEmpty()) {
-                items(uiState.courses.size) { index ->
+                items(
+                    count = uiState.courses.size,
+                    key = { index ->
+                        val course = uiState.courses[index]
+                        "${course.name}_${course.teacher}_${course.location}_${course.time}_${course.dayOfWeek}"
+                    },
+                    contentType = { "course" }
+                ) { index ->
                     val course = uiState.courses[index]
-
                     CourseCard(
                         course = course,
                         onClick = {

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/course/SelectedCourseScreen.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/course/SelectedCourseScreen.kt
@@ -91,9 +91,9 @@ fun SelectedCourseScreen(
                 .weight(1f),
             overscrollEffect = null
         ) {
-            item {
-                if (!uiState.isLoading && uiState.error == null) {
-                    // 显示上次刷新时间
+            if (!uiState.isLoading && uiState.error == null) {
+                // 显示上次刷新时间
+                item {
                     val lastRefreshText = if (uiState.lastRefreshMillis > 0L) {
                         android.text.format.DateUtils.getRelativeTimeSpanString(
                             uiState.lastRefreshMillis,
@@ -115,13 +115,21 @@ fun SelectedCourseScreen(
                             color = MiuixTheme.colorScheme.onBackgroundVariant
                         )
                     }
-
-                    uiState.courses.forEach {
-                        CourseCard(course = it, term = uiState.currentTerm)
-                        Spacer(modifier = Modifier.height(12.dp))
-                    }
                 }
-                if (uiState.isLoading) {
+
+                items(
+                    count = uiState.courses.size,
+                    key = { uiState.courses[it].className },
+                    contentType = { "course" }
+                ) { index ->
+                    val course = uiState.courses[index]
+                    CourseCard(course = course, term = uiState.currentTerm)
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
+
+            if (uiState.isLoading) {
+                item {
                     Box(
                         modifier = Modifier.fillParentMaxSize(),
                         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/score/ScoreScreen.kt
+++ b/app/src/main/java/com/lonx/ecjtu/calendar/ui/screen/score/ScoreScreen.kt
@@ -102,9 +102,9 @@ fun ScoreScreen(
                 .weight(1f),
             overscrollEffect = null
         ) {
-            item {
-                if (!uiState.isLoading && uiState.error == null) {
-                    // 显示上次刷新时间
+            if (!uiState.isLoading && uiState.error == null) {
+                // 显示上次刷新时间
+                item {
                     val lastRefreshText = if (uiState.lastRefreshMillis > 0L) {
                         android.text.format.DateUtils.getRelativeTimeSpanString(
                             uiState.lastRefreshMillis,
@@ -126,13 +126,21 @@ fun ScoreScreen(
                             color = MiuixTheme.colorScheme.onBackgroundVariant
                         )
                     }
-
-                    uiState.scores.forEach {
-                        ScoreCard(score = it, term = uiState.currentTerm)
-                        Spacer(modifier = Modifier.height(12.dp))
-                    }
                 }
-                if (uiState.isLoading) {
+
+                items(
+                    count = uiState.scores.size,
+                    key = { uiState.scores[it].courseCode },
+                    contentType = { "score" }
+                ) { index ->
+                    val score = uiState.scores[index]
+                    ScoreCard(score = score, term = uiState.currentTerm)
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
+
+            if (uiState.isLoading) {
+                item {
                     Box(
                         modifier = Modifier.fillParentMaxSize(),
                         contentAlignment = Alignment.Center


### PR DESCRIPTION
## 概述

本 PR 包含三项性能优化，主要针对数据层的多学期获取和 UI 层的列表渲染性能。

## 变更内容

### 1. 数据层：多学期并行获取 (99df46a)

**文件**：
- `data/repository/ScoreRepositoryImpl.kt`
- `data/repository/SelectedCourseRepositoryImpl.kt`

**改进**：将多学期数据获取从串行 (`forEach`) 改为并行 (`coroutineScope` + `async` + `awaitAll`)

```kotlin
// 之前：串行获取
domainPage.availableTerms.forEach { t ->
    // 获取单个学期数据
}

// 现在：并行获取
coroutineScope {
    domainPage.availableTerms.map { term ->
        async {
            // 并行获取每个学期数据
        }
    }.awaitAll()
}
```

**效果**：多个学期的数据请求并行执行，大幅减少总等待时间

### 2. UI 层：LazyColumn 渲染优化 (30c0977, 2bf81f3)

**文件**：
- `ui/screen/calendar/CalendarScreen.kt`
- `ui/screen/course/SelectedCourseScreen.kt`
- `ui/screen/score/ScoreScreen.kt`

**改进**：
- 为 `items()` 添加 `key` 参数，使用稳定的键值帮助 Compose 追踪项
- 添加 `contentType` 参数优化组合重组
- 重构条件渲染逻辑，避免在 `item` 内嵌套循环

```kotlin
// 之前
item {
    uiState.courses.forEach {
        CourseCard(course = it)
        Spacer(modifier = Modifier.height(12.dp))
    }
}

// 现在
items(
    count = uiState.courses.size,
    key = { index -> uiState.courses[index].className },
    contentType = { "course" }
) { index ->
    val course = uiState.courses[index]
    CourseCard(course = course)
    Spacer(modifier = Modifier.height(12.dp))
}
```

**效果**：减少不必要的重组，提升列表滚动流畅度

## 文件变更统计

| 文件 | 变更 |
|------|------|
| `ScoreRepositoryImpl.kt` | 73 ++++++++++++---------- |
| `SelectedCourseRepositoryImpl.kt` | 53 +++++++++------- |
| `CalendarScreen.kt` | 10 ++- |
| `SelectedCourseScreen.kt` | 24 +++--- |
| `ScoreScreen.kt` | 24 +++--- |